### PR TITLE
Implement job cancellation on Runner.stop()

### DIFF
--- a/spec/fixtures/jsjobs/return-delayed.js
+++ b/spec/fixtures/jsjobs/return-delayed.js
@@ -1,0 +1,7 @@
+
+window.jsJobRun = function(data, options, callback) {
+    var delay = data.delay || 1000;
+    setTimeout(function() {
+        return callback(null, data, null);
+    }, delay);
+};

--- a/spec/runner.coffee
+++ b/spec/runner.coffee
@@ -443,6 +443,7 @@ describe 'Runner', ->
         delay: 900
         foo: 'somedata'
       options = {}
+      chai.expect(Object.keys(solver.jobs)).to.have.length 0
       solver.runJob filter, page, options, (err, outdata, details) ->
         chai.expect(outdata).to.not.exist
         chai.expect(err).to.be.a 'object'
@@ -453,7 +454,6 @@ describe 'Runner', ->
       # XXX: relies on internal/private details
       wait 100, () ->
         jobNames = Object.keys solver.jobs
-        console.log 'killing', testRunning, jobNames
         return if not testRunning
         chai.expect(jobNames).to.have.length 1
         p = solver.jobs[jobNames[0]].process

--- a/src/runner.coffee
+++ b/src/runner.coffee
@@ -161,6 +161,7 @@ class Runner
         details.stdout = p.stdout
         details.stderr = p.stderr
       details.screenshots = job.screenshots
+      delete @jobs[job.id]
       return callback err, sol, details if err
       return callback job.error, sol, details
     @jobs[job.id] = job
@@ -211,7 +212,6 @@ class Runner
         err = new Error 'Neither solution nor error was provided' if not (out.error or out.solution)
         job.error = err
         job.process.stop()
-        delete @jobs[job.id]
         response.writeHead 204, {}
         response.end()
 


### PR DESCRIPTION
Also gives specific errors in case child process is unexpectedly terminated, and fixes a issue where `jobs` entries were not getting cleared in all cases.
